### PR TITLE
Swap AdapterInterface with Psr\Cache\CacheItemPoolInterface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,20 @@ jobs:
       install:
         - composer require symfony/cache:5.1.* symfony/dependency-injection:5.1.* symfony/framework-bundle:5.1.*
 
-    # Test against latest Symfony 5.1 stable
+    # Test against latest Symfony 5.2 stable
     - php: 7.4
       install:
         - composer require symfony/cache:5.2.* symfony/dependency-injection:5.2.* symfony/framework-bundle:5.2.*
+
+    # Test against latest Symfony 5.3 stable
+    - php: 7.4
+      install:
+        - composer require symfony/cache:5.3.* symfony/dependency-injection:5.3.* symfony/framework-bundle:5.3.*
+
+    # Test against latest Symfony 5.4 stable
+    - php: 7.4
+      install:
+        - composer require symfony/cache:5.4.* symfony/dependency-injection:5.4.* symfony/framework-bundle:5.4.*
 
     # Test dev versions
     - php: 7.4

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   ],
   "require": {
     "php": ">= 7.2.0",
-    "symfony/cache": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2" ,
-    "symfony/dependency-injection": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2",
-    "symfony/framework-bundle": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2"
+    "symfony/cache": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2 || ^5.3 || ^5.4",
+    "symfony/dependency-injection": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2 || ^5.3 || ^5.4",
+    "symfony/framework-bundle": "^4.3 || ^4.4 || ^5.0 || ^5.1 || ^5.2 || ^5.3 || ^5.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5 || ^9.0",

--- a/src/Repository/CacheRepository.php
+++ b/src/Repository/CacheRepository.php
@@ -5,22 +5,22 @@ namespace Batenburg\CacheBundle\Repository;
 use Closure;
 use Batenburg\CacheBundle\Repository\Contract\CacheRepositoryInterface;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 
 class CacheRepository implements CacheRepositoryInterface
 {
     const DEFAULT_EXPIRES_AFTER_IN_SECONDS = 3600;
 
     /**
-     * @var AdapterInterface
+     * @var CacheItemPoolInterface
      */
     private $cacheAdapter;
 
     /**
-     * @param AdapterInterface $cacheAdapter
+     * @param CacheItemPoolInterface $cacheAdapter
      */
-    public function __construct(AdapterInterface $cacheAdapter)
+    public function __construct(CacheItemPoolInterface $cacheAdapter)
     {
         $this->cacheAdapter = $cacheAdapter;
     }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -9,7 +9,7 @@
                 id="batenburg.cache_bundle.repository.cache_repository"
                 class="Batenburg\CacheBundle\Repository\CacheRepository"
                 public="false" >
-            <argument type="service" key="$cacheAdapter" id="Symfony\Component\Cache\Adapter\AdapterInterface" />
+            <argument type="service" key="$cacheAdapter" id="Psr\Cache\CacheItemPoolInterface" />
         </service>
         <service
                 id="Batenburg\CacheBundle\Repository\Contract\CacheRepositoryInterface"

--- a/tests/Unit/Repository/CacheRepositoryTest.php
+++ b/tests/Unit/Repository/CacheRepositoryTest.php
@@ -7,8 +7,8 @@ use Batenburg\CacheBundle\Repository\Contract\CacheRepositoryInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;
-use Symfony\Component\Cache\Adapter\AdapterInterface;
 
 /**
  * @covers \Batenburg\CacheBundle\Repository\CacheRepository
@@ -17,7 +17,7 @@ class CacheRepositoryTest extends TestCase
 {
 
     /**
-     * @var MockObject|AdapterInterface
+     * @var MockObject|CacheItemPoolInterface
      */
     private $cacheAdapter;
 
@@ -34,7 +34,7 @@ class CacheRepositoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->cacheAdapter    = $this->createMock(AdapterInterface::class);
+        $this->cacheAdapter    = $this->createMock(CacheItemPoolInterface::class);
         $this->cachedItem      = $this->createMock(CacheItemInterface::class);
         $this->cacheRepository = new CacheRepository($this->cacheAdapter);
     }


### PR DESCRIPTION
This swaps the wiring for `Symfony\Component\Cache\Adapter\AdapterInterface` with `Psr\Cache\CacheItemPoolInterface` as AdapterInterface's alias since symfony/framework-bundle 5.4 is deprecated.

Closes #6 